### PR TITLE
fix: prevent uncaught node exception

### DIFF
--- a/IPGeolocationAPI.js
+++ b/IPGeolocationAPI.js
@@ -224,7 +224,13 @@ function postRequest(subUrl, urlParams = '', requestData = {}, callback) {
                     'message': 'Internet is not connected!'
                 };
             } else {
-                jsonData = JSON.parse(this.responseText);
+                try {
+                    jsonData = JSON.parse(this.responseText);
+                } catch {
+                    jsonData = {
+                        'message': 'ipgeolocation.io seems to respond unexpectedly!'
+                    };
+                }
             }
 
             if (callback && typeof (callback) === typeof (Function)) {


### PR DESCRIPTION
during API hiccups.

fixes #6

---

We detected that this uncaught error led to uncaught exception in the node process (https://nodejs.org/api/process.html#process_warning_using_uncaughtexception_correctly).

This PR catches the error so it doesn't impact the stability of the whole application, to be more resilient to API outages.